### PR TITLE
Make it work on BSD by substituting gmake

### DIFF
--- a/builder/MyBuilder.pm
+++ b/builder/MyBuilder.pm
@@ -36,10 +36,14 @@ sub is_debug {
 
 sub ACTION_build {
     my $self = shift;
+    my $make = 'make';
+    if ($^O =~ /(free|net)bsd/i) {
+	$make = 'gmake';
+    }
     $self->ACTION_ppport_h() unless -e 'ppport.h';
     unless (-f "$LIBZSTD_DIR/libzstd.a") {
         local $ENV{CFLAGS} = '-O3 -fPIC';
-        $self->do_system('make' => '-C', $LIBZSTD_DIR, 'libzstd');
+        $self->do_system($make => '-C', $LIBZSTD_DIR, 'libzstd');
     }
     $self->do_system('rm', '-f', glob("$LIBZSTD_DIR/*.$Config{so}"));
     $self->SUPER::ACTION_build();


### PR DESCRIPTION
Thank you for making this module. It is a great contribution.

Currently it doesn't install on BSDs:

http://matrix.cpantesters.org/?dist=Compress-Zstd+0.02

This is because zstd uses features of Gnu Make. Gnu Make should be available under the name "gmake". This changes the file builder/MyBuilder.pm to use gmake rather than make on the FreeBSD operating system. I think this change may also work for netbsd. I have not tested it on NetBSD, but it works on FreeBSD.


Thanks again for making the module. I hope you find this contribution useful.

