### PR TITLE
Proof of concept for extra streaming support

### DIFF
--- a/lib/Compress/Zstd.xs
+++ b/lib/Compress/Zstd.xs
@@ -221,6 +221,7 @@ CODE:
     Newx(buf, bufsize, char);
     self->buf = buf;
     self->bufsize = bufsize;
+    self->status = 0 ;
     RETVAL = self;
 OUTPUT:
     RETVAL
@@ -359,6 +360,7 @@ CODE:
     Newx(buf, bufsize, char);
     self->buf = buf;
     self->bufsize = bufsize;
+    self->status = 0 ;
     RETVAL = self;
 OUTPUT:
     RETVAL

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -23,4 +23,15 @@ is ZSTD_VERSION_NUMBER, 10307;
 is ZSTD_VERSION_STRING, '1.3.7';
 is ZSTD_MAX_CLEVEL, 22;
 
+{
+    # Test an empty string
+    my $src = "";
+    ok my $compressed = compress($src, 42);
+    isnt $src, $compressed;
+    my $decompressed = decompress($compressed);
+    is uncompress($compressed), $decompressed, 'alias';
+    isnt $compressed, $decompressed;
+    is $decompressed, $src;
+}
+
 done_testing;

--- a/t/02_streaming.t
+++ b/t/02_streaming.t
@@ -11,6 +11,7 @@ cmp_ok ZSTD_DSTREAM_IN_SIZE, '>', 0;
 
 my $compressor = Compress::Zstd::Compressor->new;
 isa_ok $compressor, 'Compress::Zstd::Compressor';
+is $compressor->status(), 0;
 my $output = '';
 $output .= $compressor->compress('a');
 $output .= $compressor->compress('b');
@@ -21,11 +22,39 @@ ok $output;
 
 my $decompressor = Compress::Zstd::Decompressor->new;
 isa_ok $decompressor, 'Compress::Zstd::Decompressor';
+is $decompressor->status(), 0;
 my $result = '';
 $result .= $decompressor->decompress(substr($output, 0, 3));
-$result .= $decompressor->decompress(substr($output, 3, -1));
+isnt $decompressor->status(), 0;
+ok ! $decompressor->isEndFrame();
+
+$result .= $decompressor->decompress(substr($output, 3));
 is $result, 'abc';
+is $decompressor->status(), 0;
+ok $decompressor->isEndFrame();
+
 
 is decompress($output), 'abc';
+
+{
+    # Check can uncompress empty zstd buffer
+    my $empty = "\x28\xb5\x2f\xfd\x24\x00\x01\x00\x00\x99\xe9\xd8\x51";
+
+    my $decompressor = Compress::Zstd::Decompressor->new;
+    isa_ok $decompressor, 'Compress::Zstd::Decompressor';
+    my $result = '';
+    $result .= $decompressor->decompress(substr($empty, 0, 3));
+    isnt $decompressor->status(), 0;
+    ok ! $decompressor->isEndFrame();
+
+    $result .= $decompressor->decompress(substr($empty, 3));
+
+    is $decompressor->status(), 0;
+    ok $decompressor->isEndFrame();
+
+    is $result, '';
+
+    is decompress($empty), '';    
+}
 
 done_testing;


### PR DESCRIPTION
I have an implementation for `IO:Compress::Zstd` and `IO:Uncompress::Zstd` in progress, using `Compress-Zstd` to handle the low-level compression/uncompression, but there are a couple of things I’m blocked on.

The exiting interface for streaming uncompression will either uncompress successfully or croak on error. I need a way of knowing when a frame has been completely uncompressed. Without that I have no way of telling if the compressed data stream has been truncated. I have a generic test harness that all the IO::Compress/Uncompress modules share. One set of tests checks that I can detect truncated content.

This change is a proof-of-concept that add the following

1. Add a `status `method for the streaming interface.
This method returns the actual value returned from the streaming API calls.
3. Adds an `isEndFrame` method.
This is the key method I need
5. Exposes the `isError` & `getErrorName` functions from the ZSTD api.
These make error reporting easier for me.

With the above changes I can get `IO:Compress::Zstd` and `IO:Uncompress::Zstd`  to build & pass all tests.